### PR TITLE
fix: fix check_user_inputs zero is ok for max-idle-days

### DIFF
--- a/.github/workflows/cd-production.yaml
+++ b/.github/workflows/cd-production.yaml
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      WORKFLOW_RESULT: ${{ steps.get-previous-jobs-results.outputs.WORKFLOW_RESULT }}
+      WORKFLOW_RESULT: ${{ steps.get-overall-jobs-results.outputs.WORKFLOW_RESULT }}
 
     steps:
 

--- a/.github/workflows/cd-staging.yaml
+++ b/.github/workflows/cd-staging.yaml
@@ -134,8 +134,8 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      WORKFLOW_RESULT: ${{ steps.get-previous-jobs-results.outputs.WORKFLOW_RESULT }}
-      TAG_NAME: ${{ steps.get-previous-jobs-results.outputs.TAG_NAME }}
+      WORKFLOW_RESULT: ${{ steps.get-overall-jobs-results.outputs.WORKFLOW_RESULT }}
+      TAG_NAME: ${{ steps.get-overall-jobs-results.outputs.TAG_NAME }}
 
     steps:
 

--- a/.github/workflows/cron-tasks.yaml
+++ b/.github/workflows/cron-tasks.yaml
@@ -71,7 +71,7 @@ jobs:
         days-before-close: 3
         operations-per-run: 40
 
-  # stale-branches: # https://github.com/tagdots-dev/branch-test
+  # stale-branches: # https://github.com/tagdots-dev/action-test
   #   runs-on: ubuntu-latest
 
   #   permissions:
@@ -81,14 +81,13 @@ jobs:
   #   steps:
   #   - name: Run stale-branches
   #     id: stale-branches
-  #     uses: tagdots-dev/delete-branches@main
+  #     uses: tagdots-dev/action-test@main
   #     env:
   #       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   #     with:
   #       repo-url: ${{ github.repository }}
-  #       exclude-branch: main
-  #       exclude-branch: badges
-  #       max-idle-days: 20
+  #       max-idle-days: 14
+  #       exclude-branches: 'badges'
   #       dry-run: false
 
   update-pre-commit: # https://github.com/tagdots/update-pre-commit-action

--- a/src/pkg_32828/run.py
+++ b/src/pkg_32828/run.py
@@ -64,7 +64,7 @@ def check_user_inputs(repo, repo_url, exclude_branch, max_idle_days):
         print("❌ Error: excluded-branch must be a set")
         return False
 
-    if max_idle_days is not None and (not isinstance(max_idle_days, int) or max_idle_days <= 0):
+    if max_idle_days is not None and (not isinstance(max_idle_days, int) or max_idle_days < 0):
         print("❌ Error: max-idle-days must be an integer (0 or more)")
         return False
 


### PR DESCRIPTION
<!-- NOTE: this file is managed by terraform -->
<!-- Describe the issue -->
#### Issue Summary
_0 is not an integer; Without this fix, 0 is not an option to max-idle-days_


<!-- What's the goal of the Pull Request? -->
#### Why's this PR created?

_This PR fixes max-idle-days value bug and minor docs fixes._

