### PR TITLE
fix/remove-repo-url-in-header

### DIFF
--- a/src/pkg_32828/run.py
+++ b/src/pkg_32828/run.py
@@ -222,7 +222,6 @@ def main(dry_run, repo_url, exclude_branches, max_idle_days):
     console = Console()
     console.print(f"\n🚀 Starting to Delete GitHub Branches (\
                   dry-run: [red]{dry_run}[/red], \
-                  repo-url: [red]{repo_url}[/red], \
                   exclude-branches: [red]{set_user_exclude_branches}[/red], \
                   max-idle-days: [red]{max_idle_days}[/red])\n")
 


### PR DESCRIPTION
<!-- NOTE: this file is managed by terraform -->
<!-- What's the goal of the Pull Request? -->
#### Why's this PR created?

_This PR removes repo-url in header; I assume that most of the people use this tool via github action workflow.  By default, it uses ${{ github.repository }}.  _